### PR TITLE
Update setup instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -32,7 +32,7 @@ conda activate prof_opt
 The non-core Python packages required by the course are `pytest`, `snakeviz`, `line_profiler`, `numpy`, `pandas` and `matplotlib` which can be installed via `pip`.
  
 ```sh
-pip install pytest snakeviz line_profiler[all] numpy pandas matplotlib
+pip install pytest snakeviz "line_profiler[all]" numpy pandas matplotlib
 ```
 
 To complete some of the exercises you will need to use a text-editor or Python IDE, so make sure you have your favourite available.
@@ -47,16 +47,5 @@ pip install shapely
 
 :::::::::::::::::::::::::
 
-
-:::::::::::::::: spoiler
-
-### Mac OS (line_profiler)
-
-If you are unable to install `line_profiler` via `pip` on MacOS. Instead it can be installed via `conda`.
-
-```sh
-conda install -c conda-forge line_profiler
-```
-::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Updates the setup instructions for Python 3.13 (see #15 for status of 3.14 support) and fixes instructions for `line_profiler` installation. The double quotes are required on zsh; they are not necessary on bash but don’t have any negative effect either.

@Robadob Could you check that they don’t cause any problems on Windows, either? If they do, we’d have to re-add the info box; but if we can use the same command across all OSes, that’d be best.