### PR TITLE
add execution time output to example codes

### DIFF
--- a/episodes/files/bubblesort/bubblesort.py
+++ b/episodes/files/bubblesort/bubblesort.py
@@ -1,15 +1,19 @@
-import sys
 import random
+import sys
+import time
 
 # Argument parsing
 if len(sys.argv) != 2:
     print("Script expects 1 positive integer argument, %u found."%(len(sys.argv) - 1))
     sys.exit()
 n = int(sys.argv[1])
+
 # Init
 random.seed(12)
 arr = [random.random() for i in range(n)]
 print("Sorting %d elements"%(n))
+start_time = time.monotonic()
+
 # Sort
 for i in range(n - 1):
     swapped = False
@@ -20,9 +24,13 @@ for i in range(n - 1):
     # If no two elements were swapped in the inner loop, the array is sorted
     if not swapped:
         break
+
+end_time = time.monotonic()
+
 # Validate
 is_sorted = True
 for i in range(n - 1):
     if arr[i] > arr[i+1]:
         is_sorted = False
-print("Sorting: %s"%("Passed" if is_sorted else "Failed"))
+
+print(f"Sorting: {'Passed' if is_sorted else 'Failed'} in {end_time - start_time:.3f} s")

--- a/episodes/files/pred-prey/predprey.py
+++ b/episodes/files/pred-prey/predprey.py
@@ -1,7 +1,9 @@
-import sys
 import math
-import numpy as np
+import sys
+import time
+
 import matplotlib.pyplot as plt
+import numpy as np
 
 # Reproduction
 REPRODUCE_PREY_PROB = 0.05
@@ -424,6 +426,9 @@ steps = int(sys.argv[1])
 if steps < 1:
     print("Script expects 1 positive integer argument (number of steps), %s converts < 1."%(sys.argv[1]))
     sys.exit(1)
-        
+
+start_time = time.monotonic()
 model = Model(steps=steps)
 model.run()
+end_time = time.monotonic()
+print(f"Execution time: {end_time - start_time:.3f} s")

--- a/episodes/files/travelling-sales/travellingsales.py
+++ b/episodes/files/travelling-sales/travellingsales.py
@@ -7,6 +7,7 @@ import itertools
 import math
 import random
 import sys
+import time
 
 def distance(point1, point2):
     return math.sqrt((point2[0] - point1[0])**2 + (point2[1] - point1[1])**2)
@@ -42,7 +43,11 @@ for i in range(cities_len):
     cities.append((random.uniform(-1, 1), random.uniform(-1, 1)))
 
 # Find the shortest path
+start_time = time.monotonic()
 shortest_path, min_distance = traveling_salesman_brute_force(cities)
+end_time = time.monotonic()
+
 print("Cities:", cities_len)
 print("Shortest Path:", shortest_path)
 print("Shortest Distance:", min_distance)
+print(f"Execution time: {end_time - start_time:.3f} s")


### PR DESCRIPTION
It’s a slight usability improvement to have this info in the default output. Plus, since we mention `time.monotonic` at the start of the profiling section, this is a good way to demo it.

(I also [isort](https://github.com/pycqa/isort/)-ed the imports on those example scripts, while I was at it.)